### PR TITLE
Added ip_whitelist to helm/templates/route-web.yaml

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/templates/route-web.yaml
+++ b/helm/templates/route-web.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "NotifyBC.labels" . | nindent 4 }}
   annotations:
+    haproxy.router.openshift.io/ip_whitelist: {{ .Values.route.web.ip_whitelist }}
     haproxy.router.openshift.io/timeout: 24d
   name: {{ $fullName }}-web
 spec:

--- a/helm/templates/route-web.yaml
+++ b/helm/templates/route-web.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "NotifyBC.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.route.web.ip_whitelist }}
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.route.web.ip_whitelist }}
+    {{- end }}
     haproxy.router.openshift.io/timeout: 24d
   name: {{ $fullName }}-web
 spec:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -130,7 +130,6 @@ route:
     host: ''
     tls:
       termination: edge
-    ip_whitelist: 0.0.0.0/0
   smtp:
     host: ''
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -130,6 +130,7 @@ route:
     host: ''
     tls:
       termination: edge
+    ip_whitelist: 0.0.0.0/0
   smtp:
     host: ''
 


### PR DESCRIPTION
Added default route.web.ip_whitelist (0.0.0.0/0) to helm/values.yaml
Incremented helm/Chart.yaml to v1.1.1

This allows an IP whitelist to be set for the web route. See: https://docs.openshift.com/dedicated/3/architecture/networking/routes.html#whitelist